### PR TITLE
add missing '\n'

### DIFF
--- a/replay-log.c
+++ b/replay-log.c
@@ -60,7 +60,7 @@ static void usage(void)
 	fprintf(stderr, "\t--fsck - the fsck command to run, must specify "
 		"--check\n");
 	fprintf(stderr, "\t--check [<number>|flush|fua] when to check the "
-		"file system, mush specify --fsck");
+		"file system, mush specify --fsck\n");
 	exit(1);
 }
 


### PR DESCRIPTION
This is a subtle commit to add missing '\n' to the help string.

Signed-off-by: Naohiro Aota naota@elisp.net
